### PR TITLE
Apache CloudStack 마스터 리파지터리 변경 사항 반영

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -136,7 +136,7 @@ To create rpms, install the following extra packages:
 
     # yum -y install rpm-build
     # yum -y install ws-commons-util
-    # yum -y instal gcc
+    # yum -y install gcc
     # yum -y install glibc-devel
     # yum -y install MySQL-python
 

--- a/engine/api/src/main/java/org/apache/cloudstack/engine/orchestration/service/NetworkOrchestrationService.java
+++ b/engine/api/src/main/java/org/apache/cloudstack/engine/orchestration/service/NetworkOrchestrationService.java
@@ -129,7 +129,7 @@ public interface NetworkOrchestrationService {
 
     void cleanupNics(VirtualMachineProfile vm);
 
-    void expungeNics(VirtualMachineProfile vm);
+    void removeNics(VirtualMachineProfile vm);
 
     List<NicProfile> getNicProfiles(VirtualMachine vm);
 

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -2301,10 +2301,10 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
     }
 
     @Override
-    public void expungeNics(final VirtualMachineProfile vm) {
-        final List<NicVO> nics = _nicDao.listByVmIdIncludingRemoved(vm.getId());
+    public void removeNics(final VirtualMachineProfile vm) {
+        final List<NicVO> nics = _nicDao.listByVmId(vm.getId());
         for (final NicVO nic : nics) {
-            _nicDao.expunge(nic.getId());
+            _nicDao.remove(nic.getId());
         }
     }
 
@@ -2545,8 +2545,11 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                 && (ntwkOff.getGuestType() == GuestType.Shared || (ntwkOff.getGuestType() == GuestType.Isolated
                 && !_networkModel.areServicesSupportedByNetworkOffering(ntwkOff.getId(), Service.SourceNat)));
         if (cidr == null && ip6Cidr == null && cidrRequired) {
-            throw new InvalidParameterValueException("StartIp/endIp/gateway/netmask are required when create network of" + " type " + Network.GuestType.Shared
-                    + " and network of type " + GuestType.Isolated + " with service " + Service.SourceNat.getName() + " disabled");
+            if (ntwkOff.getGuestType() == GuestType.Shared) {
+                throw new InvalidParameterValueException("StartIp/endIp/gateway/netmask are required when create network of" + " type " + Network.GuestType.Shared);
+            } else {
+                throw new InvalidParameterValueException("gateway/netmask are required when create network of" + " type " + GuestType.Isolated + " with service " + Service.SourceNat.getName() + " disabled");
+            }
         }
 
         checkL2OfferingServices(ntwkOff);

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2247,8 +2247,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         if (MapUtils.isNotEmpty(customParams) && customParams.containsKey(GuestDef.BootType.UEFI.toString())) {
             guest.setBootType(GuestDef.BootType.UEFI);
             guest.setBootMode(GuestDef.BootMode.LEGACY);
+            guest.setMachineType("q35");
             if (StringUtils.isNotBlank(customParams.get(GuestDef.BootType.UEFI.toString())) && "secure".equalsIgnoreCase(customParams.get(GuestDef.BootType.UEFI.toString()))) {
-                guest.setMachineType("q35");
                 guest.setBootMode(GuestDef.BootMode.SECURE); // setting to secure mode
             }
         }

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -2955,7 +2955,9 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             _accountMgr.checkAccess(caller, null, true, vmInstance);
 
             currentVmOffering = _srvOfferingDao.findByIdIncludingRemoved(vmInstance.getId(), vmInstance.getServiceOfferingId());
-            sc.addAnd("id", SearchCriteria.Op.NEQ, currentVmOffering.getId());
+            if (! currentVmOffering.isDynamic()) {
+                sc.addAnd("id", SearchCriteria.Op.NEQ, currentVmOffering.getId());
+            }
 
             // 1. Only return offerings with the same storage type
             sc.addAnd("useLocalStorage", SearchCriteria.Op.EQ, currentVmOffering.isUseLocalStorage());

--- a/server/src/test/java/com/cloud/vpc/MockNetworkManagerImpl.java
+++ b/server/src/test/java/com/cloud/vpc/MockNetworkManagerImpl.java
@@ -580,10 +580,10 @@ public class MockNetworkManagerImpl extends ManagerBase implements NetworkOrches
     }
 
     /* (non-Javadoc)
-     * @see com.cloud.network.NetworkManager#expungeNics(com.cloud.vm.VirtualMachineProfile)
+     * @see com.cloud.network.NetworkManager#removeNics(com.cloud.vm.VirtualMachineProfile)
      */
     @Override
-    public void expungeNics(VirtualMachineProfile vm) {
+    public void removeNics(VirtualMachineProfile vm) {
         // TODO Auto-generated method stub
 
     }


### PR DESCRIPTION
이 PR은 Apache CloudStack의 메인 리파지터리의 주요 변경사항을 반영하기 위한 PR입니다. 

- Document의 Install Note 내용 변경
- L2 네트워크의 가상머신 NIC 변경 시 예외처리
- 다수의 네트워크에 연결되어 있는 가상머신이 이동될 때 네트워크 순서 및 IP를 유지하도록 처리
- 가상머신의 스케일 변경 시 Customer Offering으로 변경 가능하도록 개선
- Source NAT이 없는 상태로 Isolated Network을 생성할 때 잘못된 에러 메시지를 표시하는 문제 개선
- KVM에서 UEFI 가상머신을 생성할 때 Q35 chipset을 사용하도록 변경
- 여러개의 디스크를 가진 가상머신을 Import 하는 중에 사용자가 입력한 가상머신 루트 디스크를 선택하도록 기능 개선(VMWare)
- 4.14, 4.15, Master 브랜치 머징